### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/fmt.mbt
+++ b/src/fmt.mbt
@@ -12,7 +12,7 @@ fn format_part(part : FormatPart, values : Array[Json]) -> String {
         Default =>
           match value {
             Json::String(s) => s
-            Json::Number(n) => n.to_string()
+            Json::Number(n, ..) => n.to_string()
             Json::True => "true"
             Json::False => "false"
             Json::Null => "None"
@@ -29,10 +29,10 @@ fn format_part(part : FormatPart, values : Array[Json]) -> String {
 
 ///|
 fn align_string(spec : FormatSpec, value : String, sb : StringBuilder) -> Unit {
-  let width = spec.width.or(0)
+  let width = spec.width.unwrap_or(0)
   let mut value = value
   let padding = width - value.length()
-  let fill = spec.options.fill.or(' ')
+  let fill = spec.options.fill.unwrap_or(' ')
   if spec.options.sharp {
     value = match spec.typ {
       SpecType::Binary => "0b" + value
@@ -76,14 +76,22 @@ fn format_float(spec : FormatSpec, value : Json) -> String {
         value.to_string() // Default is JavaScript specific
       }
     ExponentLower =>
-      @ryu.ryu_to_string_exp(value, precision=spec.precision.or(6), upper=false)
+      @ryu.ryu_to_string_exp(
+        value,
+        precision=spec.precision.unwrap_or(6),
+        upper=false,
+      )
     ExponentUpper =>
-      @ryu.ryu_to_string_exp(value, precision=spec.precision.or(6), upper=true)
+      @ryu.ryu_to_string_exp(
+        value,
+        precision=spec.precision.unwrap_or(6),
+        upper=true,
+      )
     Percent => {
       let percent_value = value * 100.0
       @ryu.ryu_to_string_precision(
         percent_value,
-        precision=spec.precision.or(2),
+        precision=spec.precision.unwrap_or(2),
       ) +
       "%"
     }

--- a/src/fmt.mbti
+++ b/src/fmt.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "BigOrangeQWQ/fmt"
 
 import(
@@ -12,6 +13,8 @@ fn fstring(String, Array[&Formatter]) -> String
 fn jprintln(String, Json) -> Unit
 
 fn jstring(String, Json) -> String
+
+// Errors
 
 // Types and methods
 pub enum Align {

--- a/src/fmt_impl.mbt
+++ b/src/fmt_impl.mbt
@@ -1,10 +1,10 @@
 ///|
 fn _align_string(spec : FormatSpec, value : String) -> String {
   let sb = StringBuilder::new()
-  let width = spec.width.or(0)
+  let width = spec.width.unwrap_or(0)
   let mut value = value
   let padding = width - value.length()
-  let fill = spec.options.fill.or(' ')
+  let fill = spec.options.fill.unwrap_or(' ')
   if spec.options.zero {
     if spec.options.sharp {
       value = value.pad_start(width - 2, '0')
@@ -147,7 +147,7 @@ pub impl Formatter for Bool with format(self : Bool, spec : FormatSpec) -> Strin
 pub impl Formatter for Json with format(self : Json, spec : FormatSpec) -> String {
   let value = match self {
     Json::String(s) => s
-    Json::Number(n) => n.to_string()
+    Json::Number(n, ..) => n.to_string()
     Json::True => "true"
     Json::False => "false"
     Json::Null => "None"

--- a/src/fmt_parser.mbt
+++ b/src/fmt_parser.mbt
@@ -131,7 +131,7 @@ fn parse_digit(input : str) -> (Int?, str) {
   if idx == 0 {
     (None, input)
   } else {
-    (Some(result), input.charcodes(start=idx))
+    (Some(result), input.view(start_offset=idx))
   }
 }
 
@@ -183,14 +183,20 @@ fn parse_spec(input : str) -> (FormatSpec, str) {
   let (precision, rest4) = parse_precision(rest3)
   // 5. type
   let (typ, rest5) = parse_type(rest4)
-  let spec = { options, width, grouping: grouping.or_default(), precision, typ }
+  let spec = {
+    options,
+    width,
+    grouping: grouping.unwrap_or_default(),
+    precision,
+    typ,
+  }
   (spec, rest5)
 }
 
 ///|
 fn parse_format_part(input : str, last~ : Int) -> (FormatPart, str) {
   let (loc, input) = parse_digit(input)
-  let loc = loc.or(last)
+  let loc = loc.unwrap_or(last)
   let default = LocField(loc~, spec=FormatSpec::default())
   match input {
     [':', .. input] => {
@@ -212,15 +218,15 @@ fn parse_text(input : str) -> (String, str) {
     buf.write_char(char)
     idx += 1
   }
-  (buf.to_string(), input.charcodes(start=idx))
+  (buf.to_string(), input.view(start_offset=idx))
 }
 
 ///|
 fn parse_braces(input : str) -> (Char?, str) {
   if input.has_prefix("{{") {
-    (Some('{'), input.charcodes(start=2))
+    (Some('{'), input.view(start_offset=2))
   } else if input.has_prefix("}}") {
-    (Some('}'), input.charcodes(start=2))
+    (Some('}'), input.view(start_offset=2))
   } else {
     (None, input)
   }
@@ -247,7 +253,7 @@ fn parse_format_string(input : String) -> Array[FormatPart] {
     match new_chars {
       ['{', .. new_chars] => {
         let (spec, new_chars) = parse_format_part(new_chars, last~)
-        chars = new_chars.charcodes(start=1) // Skip the '}'
+        chars = new_chars.view(start_offset=1) // Skip the '}'
         last += 1
         parts.push(spec)
       }
@@ -256,7 +262,7 @@ fn parse_format_string(input : String) -> Array[FormatPart] {
           // This is a literal '}' in the format string
           buf.write_char('}')
           parts.push(Text(text=buf.to_string()))
-          chars = new_chars.charcodes(start=1) // Skip the '}'
+          chars = new_chars.view(start_offset=1) // Skip the '}'
         } else {
           // If we reach here, it means we have an unmatched '}'
           abort("Unmatched '}' in format string")


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Fix pattern matching warnings by adding ".." to Json::Number constructors 
- Replace deprecated .or() calls with .unwrap_or()
- Replace deprecated .or_default() with .unwrap_or_default() 
- Replace deprecated .charcodes(start=) with .view(start_offset=)

All warnings resolved:
- warning[0021]: Missing ".." for omitted constructor arguments
- warning[2000]: Deprecated API usage warnings

Changes span across fmt.mbt, fmt_impl.mbt, and fmt_parser.mbt files.